### PR TITLE
fix: handle readonly file system command

### DIFF
--- a/packages/file-system-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/file-system-worker/src/parts/CommandMap/CommandMap.ts
@@ -19,6 +19,7 @@ export const commandMap: Record<string, any> = {
   'FileSystem.getPathSeparator': FileSystem.getPathSeparator,
   'FileSystem.getRealPath': FileSystem.getRealPath,
   'FileSystem.handleMessagePort': HandleMessagePort.handleMessagePort,
+  'FileSystem.isReadonly': FileSystem.isReadonly,
   'FileSystem.mkdir': FileSystem.mkdir,
   'FileSystem.readDirWithFileTypes': FileSystem.readDirWithFileTypes,
   'FileSystem.readFile': FileSystem.readFile,

--- a/packages/file-system-worker/src/parts/FileSystemDisk/FileSystemDisk.ts
+++ b/packages/file-system-worker/src/parts/FileSystemDisk/FileSystemDisk.ts
@@ -37,6 +37,10 @@ export const getPathSeparator = async (root: string): Promise<string> => {
   return FileSystemProcess.getPathSeparator(root)
 }
 
+export const isReadonly = async (uri: string): Promise<boolean> => {
+  return FileSystemProcess.invoke('FileSystem.isReadonly', uri)
+}
+
 export const readJson = async (uri: string): Promise<any> => {
   if (isHttp(uri)) {
     return FileSystemFetch.readJson(uri)

--- a/packages/file-system-worker/test/CommandMap.test.ts
+++ b/packages/file-system-worker/test/CommandMap.test.ts
@@ -3,4 +3,5 @@ import * as CommandMap from '../src/parts/CommandMap/CommandMap.ts'
 
 test('commandMap', async () => {
   expect(typeof CommandMap.commandMap).toBe('object')
+  expect(typeof CommandMap.commandMap['FileSystem.isReadonly']).toBe('function')
 })

--- a/packages/file-system-worker/test/FileSystemDisk.test.ts
+++ b/packages/file-system-worker/test/FileSystemDisk.test.ts
@@ -16,6 +16,7 @@ const createMockFileSystemRpcs = (): {
       'FileSystem.copy': async (oldUri: string, newUri: string) => mockInvoke('FileSystem.copy', oldUri, newUri),
       'FileSystem.getPathSeparator': async (root: string) => mockInvoke('FileSystem.getPathSeparator', root),
       'FileSystem.getRealPath': async (path: string) => mockInvoke('FileSystem.getRealPath', path),
+      'FileSystem.isReadonly': async (uri: string) => mockInvoke('FileSystem.isReadonly', uri),
       'FileSystem.mkdir': async (uri: string) => mockInvoke('FileSystem.mkdir', uri),
       'FileSystem.readDirWithFileTypes': async (uri: string) => mockInvoke('FileSystem.readDirWithFileTypes', uri),
       'FileSystem.readFile': async (uri: string) => mockInvoke('FileSystem.readFile', uri),
@@ -92,6 +93,19 @@ test('getPathSeparator', async () => {
   const separator = await FileSystemDisk.getPathSeparator('/test/path')
   expect(separator).toBe('/')
   expect(mockRpc.invocations).toEqual([['FileSystem.getPathSeparator', '/test/path']])
+})
+
+test('isReadonly', async () => {
+  const { mockRpc } = createMockFileSystemRpcs()
+  mockInvoke.mockImplementation(async (method: string) => {
+    if (method === 'FileSystem.isReadonly') {
+      return true
+    }
+    throw new Error(`unexpected method ${method}`)
+  })
+  const isReadonly = await FileSystemDisk.isReadonly('file:///test/path')
+  expect(isReadonly).toBe(true)
+  expect(mockRpc.invocations).toEqual([['FileSystem.isReadonly', 'file:///test/path']])
 })
 
 test('readJson', async () => {


### PR DESCRIPTION
Expose the readonly file-system command in the worker and forward disk URI checks to the file-system process. This lets Explorer open disk folders without a missing-command error while preserving readonly detection.