### PR TITLE
feature: add file hash command

### DIFF
--- a/packages/file-system-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/file-system-worker/src/parts/CommandMap/CommandMap.ts
@@ -15,6 +15,7 @@ export const commandMap: Record<string, any> = {
   'FileSystem.createFile': FileSystem.createFile,
   'FileSystem.executeWatchCallback': FileWatcher.executeWatchCallback,
   'FileSystem.exists': FileSystem.exists,
+  'FileSystem.getFileHash': FileSystem.getFileHash,
   'FileSystem.getFolderSize': FileSystem.getFolderSize,
   'FileSystem.getPathSeparator': FileSystem.getPathSeparator,
   'FileSystem.getRealPath': FileSystem.getRealPath,

--- a/packages/file-system-worker/src/parts/FileSystemDisk/FileSystemDisk.ts
+++ b/packages/file-system-worker/src/parts/FileSystemDisk/FileSystemDisk.ts
@@ -22,6 +22,10 @@ export const readFile = async (uri: string): Promise<string> => {
   return FileSystemProcess.readFile(uri)
 }
 
+export const getFileHash = async (uri: string): Promise<string> => {
+  return FileSystemProcess.getFileHash(uri)
+}
+
 export const appendFile = async (uri: string, text: string): Promise<string> => {
   return FileSystemProcess.appendFile(uri, text)
 }

--- a/packages/file-system-worker/src/parts/FileSystemProcess/FileSystemProcess.ts
+++ b/packages/file-system-worker/src/parts/FileSystemProcess/FileSystemProcess.ts
@@ -1,5 +1,9 @@
 import { FileSystemProcess } from '@lvce-editor/rpc-registry'
 
+export const getFileHash = async (uri: string): Promise<string> => {
+  return FileSystemProcess.invoke('FileSystem.getFileHash', uri)
+}
+
 export const {
   appendFile,
   copy,

--- a/packages/file-system-worker/test/CommandMap.test.ts
+++ b/packages/file-system-worker/test/CommandMap.test.ts
@@ -3,5 +3,6 @@ import * as CommandMap from '../src/parts/CommandMap/CommandMap.ts'
 
 test('commandMap', async () => {
   expect(typeof CommandMap.commandMap).toBe('object')
+  expect(typeof CommandMap.commandMap['FileSystem.getFileHash']).toBe('function')
   expect(typeof CommandMap.commandMap['FileSystem.isReadonly']).toBe('function')
 })

--- a/packages/file-system-worker/test/FileSystemDisk.test.ts
+++ b/packages/file-system-worker/test/FileSystemDisk.test.ts
@@ -14,6 +14,7 @@ const createMockFileSystemRpcs = (): {
   const mockRpc = createMockRpc({
     commandMap: {
       'FileSystem.copy': async (oldUri: string, newUri: string) => mockInvoke('FileSystem.copy', oldUri, newUri),
+      'FileSystem.getFileHash': async (uri: string) => mockInvoke('FileSystem.getFileHash', uri),
       'FileSystem.getPathSeparator': async (root: string) => mockInvoke('FileSystem.getPathSeparator', root),
       'FileSystem.getRealPath': async (path: string) => mockInvoke('FileSystem.getRealPath', path),
       'FileSystem.isReadonly': async (uri: string) => mockInvoke('FileSystem.isReadonly', uri),
@@ -67,6 +68,21 @@ test('readFile', async () => {
   const content = await FileSystemDisk.readFile('/test/path')
   expect(content).toBe('file content')
   expect(mockRpc.invocations).toEqual([['FileSystem.readFile', '/test/path']])
+})
+
+test('getFileHash', async () => {
+  const { mockRpc } = createMockFileSystemRpcs()
+  mockInvoke.mockImplementation(async (method: string) => {
+    if (method === 'FileSystem.getFileHash') {
+      return 'test-hash'
+    }
+    throw new Error(`unexpected method ${method}`)
+  })
+
+  const hash = await FileSystemDisk.getFileHash('/test/path')
+
+  expect(hash).toBe('test-hash')
+  expect(mockRpc.invocations).toEqual([['FileSystem.getFileHash', '/test/path']])
 })
 
 test('readDirWithFileTypes', async () => {


### PR DESCRIPTION
Expose file hashing through the file-system worker so callers can validate cached content without transferring the full file.