### PR TITLE
fix: clarify unavailable web disk file system

### DIFF
--- a/packages/file-system-worker/src/parts/CreateUnavailableFileSystemProcessRpc/CreateUnavailableFileSystemProcessRpc.ts
+++ b/packages/file-system-worker/src/parts/CreateUnavailableFileSystemProcessRpc/CreateUnavailableFileSystemProcessRpc.ts
@@ -1,0 +1,18 @@
+import type { Rpc } from '@lvce-editor/rpc'
+
+const throwUnavailableError = (): never => {
+  throw new Error('Disk file system is not available in web')
+}
+
+export const createUnavailableFileSystemProcessRpc = (): Rpc => {
+  return {
+    dispose: async (): Promise<void> => {},
+    invoke: async (): Promise<never> => {
+      return throwUnavailableError()
+    },
+    invokeAndTransfer: async (): Promise<never> => {
+      return throwUnavailableError()
+    },
+    send: throwUnavailableError,
+  }
+}

--- a/packages/file-system-worker/src/parts/InitializeFileSystemProcess/InitializeFileSystemProcess.ts
+++ b/packages/file-system-worker/src/parts/InitializeFileSystemProcess/InitializeFileSystemProcess.ts
@@ -1,9 +1,11 @@
 import { createFileSystemProcessRpc } from '../CreateFileSystemProcessRpc/CreateFileSystemProcessRpc.ts'
+import { createUnavailableFileSystemProcessRpc } from '../CreateUnavailableFileSystemProcessRpc/CreateUnavailableFileSystemProcessRpc.ts'
 import * as FileSystemProcess from '../FileSystemProcess/FileSystemProcess.ts'
 import * as PlatformType from '../PlatformType/PlatformType.ts'
 
 export const initializeFileSystemProcess = async (platform: number): Promise<void> => {
   if (platform === PlatformType.Web) {
+    FileSystemProcess.set(createUnavailableFileSystemProcessRpc())
     return
   }
   const rpc = await createFileSystemProcessRpc(platform)

--- a/packages/file-system-worker/test/CreateUnavailableFileSystemProcessRpc.test.ts
+++ b/packages/file-system-worker/test/CreateUnavailableFileSystemProcessRpc.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@jest/globals'
+import { createUnavailableFileSystemProcessRpc } from '../src/parts/CreateUnavailableFileSystemProcessRpc/CreateUnavailableFileSystemProcessRpc.ts'
+
+test('throws a clear error when invoked', async () => {
+  const rpc = createUnavailableFileSystemProcessRpc()
+
+  await expect(rpc.invoke('FileSystem.readFile', '/test/config.json')).rejects.toThrow('Disk file system is not available in web')
+})

--- a/packages/file-system-worker/test/Initialize.test.ts
+++ b/packages/file-system-worker/test/Initialize.test.ts
@@ -1,8 +1,8 @@
 import { expect, jest, test } from '@jest/globals'
 import { createMockRpc } from '@lvce-editor/rpc'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
-import { RpcId, get } from '@lvce-editor/rpc-registry'
+import { RendererWorker, RpcId, get } from '@lvce-editor/rpc-registry'
 import { initialize } from '../src/parts/Initialize/Initialize.ts'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.ts'
 
 test('initialize', async () => {
   const mockInvokeAndTransfer = jest.fn()
@@ -24,4 +24,11 @@ test('initialize', async () => {
   ])
   expect(rpc).toBeDefined()
   await rpc.dispose()
+})
+
+test('initialize - web installs unavailable disk file system rpc', async () => {
+  await initialize(PlatformType.Web)
+
+  const rpc = get(RpcId.FileSystemProcess)
+  await expect(rpc.invoke('FileSystem.readFile', '/test/config.json')).rejects.toThrow('Disk file system is not available in web')
 })


### PR DESCRIPTION
Install an explicit unavailable disk filesystem RPC on web so accidental disk access reports a clear platform-specific error.