### PR TITLE
fix: support fetch file systems on web

### DIFF
--- a/packages/file-system-worker/src/parts/FileSystemDisk/FileSystemDisk.ts
+++ b/packages/file-system-worker/src/parts/FileSystemDisk/FileSystemDisk.ts
@@ -2,6 +2,7 @@ import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as FileSystemFetch from '../FileSystemFetch/FileSystemFetch.ts'
 import * as FileSystemMemory from '../FileSystemMemory/FileSystemMemory.ts'
 import * as FileSystemProcess from '../FileSystemProcess/FileSystemProcess.ts'
+import { isFetch } from '../IsFetch/IsFetch.ts'
 import { isHttp } from '../IsHttp/IsHttp.ts'
 import { isMemory } from '../IsMemory/IsMemory.ts'
 
@@ -13,6 +14,9 @@ export const remove = async (dirent: string): Promise<void> => {
 }
 
 export const readFile = async (uri: string): Promise<string> => {
+  if (isFetch(uri)) {
+    return RendererWorker.invoke('FileSystem.readFile', uri)
+  }
   if (isHttp(uri)) {
     return FileSystemFetch.readFile(uri)
   }
@@ -31,6 +35,9 @@ export const appendFile = async (uri: string, text: string): Promise<string> => 
 }
 
 export const readDirWithFileTypes = async (uri: string): Promise<readonly any[]> => {
+  if (isFetch(uri)) {
+    return RendererWorker.invoke('FileSystem.readDirWithFileTypes', uri)
+  }
   if (isMemory(uri)) {
     return RendererWorker.invoke('FileSystem.readDirWithFileTypes', uri)
   }
@@ -84,6 +91,9 @@ export const stat = async (dirent: string): Promise<any> => {
 }
 
 export const exists = async (uri: string): Promise<any> => {
+  if (isFetch(uri)) {
+    return RendererWorker.invoke('FileSystem.exists', uri)
+  }
   if (isHttp(uri)) {
     return FileSystemFetch.exists(uri)
   }

--- a/packages/file-system-worker/src/parts/IsFetch/IsFetch.ts
+++ b/packages/file-system-worker/src/parts/IsFetch/IsFetch.ts
@@ -1,0 +1,5 @@
+import * as Protocol from '../Protocol/Protocol.ts'
+
+export const isFetch = (uri: string): boolean => {
+  return uri.startsWith(Protocol.Fetch)
+}

--- a/packages/file-system-worker/src/parts/Protocol/Protocol.ts
+++ b/packages/file-system-worker/src/parts/Protocol/Protocol.ts
@@ -2,3 +2,5 @@ export const Http = 'http:'
 export const Memory = 'memfs:'
 export const Https = 'https:'
 export const File = 'file:'
+
+export const Fetch = 'fetch:'

--- a/packages/file-system-worker/test/FileSystemDisk.test.ts
+++ b/packages/file-system-worker/test/FileSystemDisk.test.ts
@@ -1,15 +1,17 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import { createMockRpc } from '@lvce-editor/rpc'
-import { ExtensionHost } from '@lvce-editor/rpc-registry'
+import { ExtensionHost, RendererWorker } from '@lvce-editor/rpc-registry'
 import * as FileSystemDisk from '../src/parts/FileSystemDisk/FileSystemDisk.js'
 import * as FileSystemProcess from '../src/parts/FileSystemProcess/FileSystemProcess.js'
 
 const mockInvoke = jest.fn<(method: string, ...args: readonly unknown[]) => Promise<unknown>>()
 const mockExtensionHostInvoke = jest.fn<(method: string, ...args: readonly unknown[]) => Promise<unknown>>()
+const mockRendererWorkerInvoke = jest.fn<(method: string, ...args: readonly unknown[]) => Promise<unknown>>()
 
 const createMockFileSystemRpcs = (): {
   mockRpc: ReturnType<typeof createMockRpc>
   mockExtensionHostRpc: ReturnType<typeof createMockRpc>
+  mockRendererWorkerRpc: ReturnType<typeof createMockRpc>
 } => {
   const mockRpc = createMockRpc({
     commandMap: {
@@ -34,15 +36,24 @@ const createMockFileSystemRpcs = (): {
       'FileSystemMemory.readFile': async (uri: string) => mockExtensionHostInvoke('FileSystemMemory.readFile', uri),
     },
   })
+  const mockRendererWorkerRpc = createMockRpc({
+    commandMap: {
+      'FileSystem.exists': async (uri: string) => mockRendererWorkerInvoke('FileSystem.exists', uri),
+      'FileSystem.readDirWithFileTypes': async (uri: string) => mockRendererWorkerInvoke('FileSystem.readDirWithFileTypes', uri),
+      'FileSystem.readFile': async (uri: string) => mockRendererWorkerInvoke('FileSystem.readFile', uri),
+    },
+  })
   FileSystemProcess.set(mockRpc)
   ExtensionHost.set(mockExtensionHostRpc)
-  return { mockExtensionHostRpc, mockRpc }
+  RendererWorker.set(mockRendererWorkerRpc)
+  return { mockExtensionHostRpc, mockRendererWorkerRpc, mockRpc }
 }
 
 beforeEach(() => {
   jest.resetAllMocks()
   mockInvoke.mockReset()
   mockExtensionHostInvoke.mockReset()
+  mockRendererWorkerInvoke.mockReset()
 })
 
 test('remove', async () => {
@@ -68,6 +79,26 @@ test('readFile', async () => {
   const content = await FileSystemDisk.readFile('/test/path')
   expect(content).toBe('file content')
   expect(mockRpc.invocations).toEqual([['FileSystem.readFile', '/test/path']])
+})
+
+test('readFile routes fetch uri to renderer worker', async () => {
+  const { mockRendererWorkerRpc } = createMockFileSystemRpcs()
+  mockRendererWorkerInvoke.mockResolvedValue('file content')
+
+  const content = await FileSystemDisk.readFile('fetch:///workspace/file.ts')
+
+  expect(content).toBe('file content')
+  expect(mockRendererWorkerRpc.invocations).toEqual([['FileSystem.readFile', 'fetch:///workspace/file.ts']])
+})
+
+test('exists routes fetch uri to renderer worker', async () => {
+  const { mockRendererWorkerRpc } = createMockFileSystemRpcs()
+  mockRendererWorkerInvoke.mockResolvedValue(true)
+
+  const exists = await FileSystemDisk.exists('fetch:///workspace/file.ts')
+
+  expect(exists).toBe(true)
+  expect(mockRendererWorkerRpc.invocations).toEqual([['FileSystem.exists', 'fetch:///workspace/file.ts']])
 })
 
 test('getFileHash', async () => {
@@ -96,6 +127,16 @@ test('readDirWithFileTypes', async () => {
   const files = await FileSystemDisk.readDirWithFileTypes('/test/path')
   expect(files).toEqual([{ name: 'file1' }, { name: 'file2' }])
   expect(mockRpc.invocations).toEqual([['FileSystem.readDirWithFileTypes', '/test/path']])
+})
+
+test('readDirWithFileTypes routes fetch uri to renderer worker', async () => {
+  const { mockRendererWorkerRpc } = createMockFileSystemRpcs()
+  mockRendererWorkerInvoke.mockResolvedValue([{ name: 'file.ts' }])
+
+  const files = await FileSystemDisk.readDirWithFileTypes('fetch:///workspace')
+
+  expect(files).toEqual([{ name: 'file.ts' }])
+  expect(mockRendererWorkerRpc.invocations).toEqual([['FileSystem.readDirWithFileTypes', 'fetch:///workspace']])
 })
 
 test('getPathSeparator', async () => {


### PR DESCRIPTION
Summary:
- route fetch-backed workspace reads through the renderer on web
- support file reads, directory reads, and existence checks
- add regression coverage for each fetch operation