### PR TITLE
feature: update rpc to version 6.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3189,14 +3189,14 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.11.0.tgz",
-      "integrity": "sha512-Hvte166d7Hjf8roIx5Z4ZRSS5sQZUEa7lkw20yjfp2MeOp4GQO9XAUL+2ca7J6wtPfIAYRlEL3av4YAYztoLIw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.12.0.tgz",
+      "integrity": "sha512-qLaGwjenfbE/3e2LzOsPJazonyZ9GMHbOdYloBtNtzjdd3mre3lFIuCV4D8prq5P1quFiAlGRlgNCDPhb/G7Bg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.4.0",
+        "@lvce-editor/ipc": "^16.6.0",
         "@lvce-editor/json-rpc": "^8.4.0",
         "@lvce-editor/verror": "^1.7.0"
       }
@@ -14720,40 +14720,12 @@
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^30.4.1",
-        "@lvce-editor/rpc": "^6.4.0",
+        "@lvce-editor/rpc": "^6.12.0",
         "@lvce-editor/rpc-registry": "^9.23.0",
         "@lvce-editor/verror": "^1.7.0",
         "blob-util": "^2.0.2",
         "jest": "^30.4.2",
         "ts-jest": "^29.4.10"
-      }
-    },
-    "packages/file-system-worker/node_modules/@lvce-editor/ipc": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-15.0.0.tgz",
-      "integrity": "sha512-PY8HVhuShfGaTgTSgrsgwgv7Po3WPkgh9AlilgYull4yFPKYZphlGogMSudxq+IsdhKYjD7hdncUEoox+idXiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "packages/file-system-worker/node_modules/@lvce-editor/rpc": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.4.0.tgz",
-      "integrity": "sha512-AhIyFrPz9/9usLNSLNdMtHxSmrfYw4TfJXRMV19px/eYOv+Y20pEq3O31HtKejZaUVRUbPhhJ0EOa0z9YsGAcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^15.0.0",
-        "@lvce-editor/json-rpc": "^8.0.0"
       }
     },
     "packages/file-system-worker/node_modules/@lvce-editor/rpc-registry": {

--- a/packages/file-system-worker/package.json
+++ b/packages/file-system-worker/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",
-    "@lvce-editor/rpc": "^6.4.0",
+    "@lvce-editor/rpc": "^6.12.0",
     "@lvce-editor/rpc-registry": "^9.23.0",
     "@lvce-editor/verror": "^1.7.0",
     "blob-util": "^2.0.2",

--- a/packages/file-system-worker/test/CreateFileSystemProcessRpcNode.test.ts
+++ b/packages/file-system-worker/test/CreateFileSystemProcessRpcNode.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, expect, test } from '@jest/globals'
+import { beforeAll, expect, jest, test } from '@jest/globals'
 import { createFileSystemProcessRpcNode } from '../src/parts/CreateFileSystemProcessRpcNode/CreateFileSystemProcessRpcNode.js'
 
 beforeAll(() => {
@@ -33,6 +33,7 @@ test('creates file system process rpc', async () => {
 })
 
 test('handles error when creating file system process rpc', async () => {
+  jest.useFakeTimers()
   class MockWebSocket extends EventTarget {
     constructor() {
       super()
@@ -48,7 +49,17 @@ test('handles error when creating file system process rpc', async () => {
     configurable: true,
     value: MockWebSocket,
   })
-  await expect(createFileSystemProcessRpcNode()).rejects.toThrow(
-    new Error('Failed to create file system process rpc: IpcError: Websocket connection was immediately closed'),
-  )
+  const rpcPromise = createFileSystemProcessRpcNode()
+  const errorPromise = (async (): Promise<unknown> => {
+    try {
+      return await rpcPromise
+    } catch (error) {
+      return error
+    }
+  })()
+  await jest.runAllTimersAsync()
+  await expect(errorPromise).resolves.toMatchObject({
+    message: 'Failed to create file system process rpc: Failed to create rpc connection: IpcError: Websocket connection was immediately closed',
+  })
+  jest.useRealTimers()
 })


### PR DESCRIPTION
## Summary

- update `@lvce-editor/rpc` to 6.12.0 so file-system process startup retries one transient WebSocket handshake failure
- update the connection-error test for the current wrapped error and make its retry delay deterministic with fake timers

## Validation

- `npm run build`
- `npm run build:static`
- `npm test --workspace @lvce-editor/file-system-worker -- --runInBand`
- `npm run test-integration`
- `npm run type-check`
- `npm run lint`