### PR TITLE
fix: support html file systems on web

### DIFF
--- a/packages/file-system-worker/src/parts/FileSystemDisk/FileSystemDisk.ts
+++ b/packages/file-system-worker/src/parts/FileSystemDisk/FileSystemDisk.ts
@@ -3,6 +3,7 @@ import * as FileSystemFetch from '../FileSystemFetch/FileSystemFetch.ts'
 import * as FileSystemMemory from '../FileSystemMemory/FileSystemMemory.ts'
 import * as FileSystemProcess from '../FileSystemProcess/FileSystemProcess.ts'
 import { isFetch } from '../IsFetch/IsFetch.ts'
+import { isHtml } from '../IsHtml/IsHtml.ts'
 import { isHttp } from '../IsHttp/IsHttp.ts'
 import { isMemory } from '../IsMemory/IsMemory.ts'
 
@@ -14,7 +15,7 @@ export const remove = async (dirent: string): Promise<void> => {
 }
 
 export const readFile = async (uri: string): Promise<string> => {
-  if (isFetch(uri)) {
+  if (isFetch(uri) || isHtml(uri)) {
     return RendererWorker.invoke('FileSystem.readFile', uri)
   }
   if (isHttp(uri)) {
@@ -35,7 +36,7 @@ export const appendFile = async (uri: string, text: string): Promise<string> => 
 }
 
 export const readDirWithFileTypes = async (uri: string): Promise<readonly any[]> => {
-  if (isFetch(uri)) {
+  if (isFetch(uri) || isHtml(uri)) {
     return RendererWorker.invoke('FileSystem.readDirWithFileTypes', uri)
   }
   if (isMemory(uri)) {
@@ -91,7 +92,7 @@ export const stat = async (dirent: string): Promise<any> => {
 }
 
 export const exists = async (uri: string): Promise<any> => {
-  if (isFetch(uri)) {
+  if (isFetch(uri) || isHtml(uri)) {
     return RendererWorker.invoke('FileSystem.exists', uri)
   }
   if (isHttp(uri)) {

--- a/packages/file-system-worker/src/parts/IsHtml/IsHtml.ts
+++ b/packages/file-system-worker/src/parts/IsHtml/IsHtml.ts
@@ -1,0 +1,5 @@
+import * as Protocol from '../Protocol/Protocol.ts'
+
+export const isHtml = (uri: string): boolean => {
+  return uri.startsWith(Protocol.Html)
+}

--- a/packages/file-system-worker/src/parts/Protocol/Protocol.ts
+++ b/packages/file-system-worker/src/parts/Protocol/Protocol.ts
@@ -4,3 +4,5 @@ export const Https = 'https:'
 export const File = 'file:'
 
 export const Fetch = 'fetch:'
+
+export const Html = 'html:'

--- a/packages/file-system-worker/test/FileSystemDisk.test.ts
+++ b/packages/file-system-worker/test/FileSystemDisk.test.ts
@@ -91,6 +91,16 @@ test('readFile routes fetch uri to renderer worker', async () => {
   expect(mockRendererWorkerRpc.invocations).toEqual([['FileSystem.readFile', 'fetch:///workspace/file.ts']])
 })
 
+test('readFile routes html uri to renderer worker', async () => {
+  const { mockRendererWorkerRpc } = createMockFileSystemRpcs()
+  mockRendererWorkerInvoke.mockResolvedValue('file content')
+
+  const content = await FileSystemDisk.readFile('html:///workspace/file.ts')
+
+  expect(content).toBe('file content')
+  expect(mockRendererWorkerRpc.invocations).toEqual([['FileSystem.readFile', 'html:///workspace/file.ts']])
+})
+
 test('exists routes fetch uri to renderer worker', async () => {
   const { mockRendererWorkerRpc } = createMockFileSystemRpcs()
   mockRendererWorkerInvoke.mockResolvedValue(true)
@@ -99,6 +109,16 @@ test('exists routes fetch uri to renderer worker', async () => {
 
   expect(exists).toBe(true)
   expect(mockRendererWorkerRpc.invocations).toEqual([['FileSystem.exists', 'fetch:///workspace/file.ts']])
+})
+
+test('exists routes html uri to renderer worker', async () => {
+  const { mockRendererWorkerRpc } = createMockFileSystemRpcs()
+  mockRendererWorkerInvoke.mockResolvedValue(true)
+
+  const exists = await FileSystemDisk.exists('html:///workspace/file.ts')
+
+  expect(exists).toBe(true)
+  expect(mockRendererWorkerRpc.invocations).toEqual([['FileSystem.exists', 'html:///workspace/file.ts']])
 })
 
 test('getFileHash', async () => {
@@ -137,6 +157,16 @@ test('readDirWithFileTypes routes fetch uri to renderer worker', async () => {
 
   expect(files).toEqual([{ name: 'file.ts' }])
   expect(mockRendererWorkerRpc.invocations).toEqual([['FileSystem.readDirWithFileTypes', 'fetch:///workspace']])
+})
+
+test('readDirWithFileTypes routes html uri to renderer worker', async () => {
+  const { mockRendererWorkerRpc } = createMockFileSystemRpcs()
+  mockRendererWorkerInvoke.mockResolvedValue([{ name: 'file.ts' }])
+
+  const files = await FileSystemDisk.readDirWithFileTypes('html:///workspace')
+
+  expect(files).toEqual([{ name: 'file.ts' }])
+  expect(mockRendererWorkerRpc.invocations).toEqual([['FileSystem.readDirWithFileTypes', 'html:///workspace']])
 })
 
 test('getPathSeparator', async () => {


### PR DESCRIPTION
Summary:
- route HTML-backed workspace reads through the renderer on web
- support file reads, directory reads, and existence checks
- add regression coverage for each HTML filesystem operation