### PR TITLE
Request WebSocket capabilities for filesystem RPC

### DIFF
--- a/packages/file-system-worker/src/parts/CreateFileSystemProcessRpcNode/CreateFileSystemProcessRpcNode.ts
+++ b/packages/file-system-worker/src/parts/CreateFileSystemProcessRpcNode/CreateFileSystemProcessRpcNode.ts
@@ -1,9 +1,24 @@
-import { type Rpc, WebSocketRpcParent2 } from '@lvce-editor/rpc'
+import { type Rpc, WebSocketRpcParent, WebSocketRpcParent2 } from '@lvce-editor/rpc'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import { VError } from '@lvce-editor/verror'
 import * as CommandMapRef from '../CommandMapRef/CommandMapRef.ts'
 
 export const createFileSystemProcessRpcNode = async (): Promise<Rpc> => {
   try {
+    try {
+      const { protocols, url } = (await RendererWorker.invoke('WebSocketCapability.create', 'file-system-process')) as {
+        readonly protocols: string[]
+        readonly url: string
+      }
+      return await WebSocketRpcParent.create({
+        commandMap: CommandMapRef.commandMapRef,
+        webSocket: new WebSocket(url, protocols),
+      })
+    } catch (error) {
+      if (!(error instanceof Error && error.message.includes('WebSocketCapability.create') && /command not found|not found/i.test(error.message))) {
+        throw error
+      }
+    }
     const rpc = await WebSocketRpcParent2.create({
       commandMap: CommandMapRef.commandMapRef,
       type: 'file-system-process',

--- a/packages/file-system-worker/test/CreateFileSystemProcessRpcNode.test.ts
+++ b/packages/file-system-worker/test/CreateFileSystemProcessRpcNode.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, expect, jest, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import { createFileSystemProcessRpcNode } from '../src/parts/CreateFileSystemProcessRpcNode/CreateFileSystemProcessRpcNode.js'
 
 beforeAll(() => {
@@ -12,6 +13,11 @@ beforeAll(() => {
 })
 
 test('creates file system process rpc', async () => {
+  const rendererWorker = RendererWorker.registerMockRpc({
+    'WebSocketCapability.create'(): unknown {
+      return { protocols: ['lvce-rpc', 'lvce-capability.token'], url: 'ws://localhost/websocket/capability' }
+    },
+  })
   class MockWebSocket extends EventTarget {
     constructor() {
       super()
@@ -27,12 +33,21 @@ test('creates file system process rpc', async () => {
     configurable: true,
     value: MockWebSocket,
   })
-  const rpc = await createFileSystemProcessRpcNode()
-  expect(rpc).toBeDefined()
-  await rpc.dispose()
+  try {
+    const rpc = await createFileSystemProcessRpcNode()
+    expect(rpc).toBeDefined()
+    await rpc.dispose()
+  } finally {
+    rendererWorker[Symbol.dispose]()
+  }
 })
 
 test('handles error when creating file system process rpc', async () => {
+  const rendererWorker = RendererWorker.registerMockRpc({
+    'WebSocketCapability.create'(): unknown {
+      return { protocols: ['lvce-rpc', 'lvce-capability.token'], url: 'ws://localhost/websocket/capability' }
+    },
+  })
   jest.useFakeTimers()
   class MockWebSocket extends EventTarget {
     constructor() {
@@ -61,5 +76,6 @@ test('handles error when creating file system process rpc', async () => {
   await expect(errorPromise).resolves.toMatchObject({
     message: 'Failed to create file system process rpc: Failed to create rpc connection: IpcError: Websocket connection was immediately closed',
   })
+  rendererWorker[Symbol.dispose]()
   jest.useRealTimers()
 })


### PR DESCRIPTION
Requests a renderer-issued one-use capability before connecting to the filesystem process, with a command-missing fallback for older editors.